### PR TITLE
update the package cache so install succeeds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM martenseemann/quic-network-simulator-endpoint:latest
 
-RUN apt-get install -y wget tar git vim python
+RUN apt-get update && apt-get install -y wget tar git vim python
 
 RUN wget https://dl.google.com/go/go1.12.7.linux-amd64.tar.gz && \
   tar xfz go1.12.7.linux-amd64.tar.gz && \


### PR DESCRIPTION
I think the base docker image is out of date, so just trying apt-get install fails.